### PR TITLE
Check incoming OR outgoing messages

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -18,7 +18,7 @@ export const CONTAINER_URI_PREFIX = 'http://redpencil.data.gift/id/dataContainer
 
 export const SERVICE_NAME = 'http://lblod.data.gift/services/berichtencentrum-warning-service';
 export const JOB_OPERATION = 'http://lblod.data.gift/id/jobs/concept/JobOperation/berichtencentrumWarning';
-export const CHECK_SENT_MESSAGES_OPERATION = 'http://lblod.data.gift/id/jobs/concept/JobOperation/checkSentMessages';
+export const CHECK_MESSAGES_OPERATION = 'http://lblod.data.gift/id/jobs/concept/JobOperation/checkMessages';
 
 export const PREFIXES = `
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -42,7 +42,7 @@ export const WARNING_EMAIL_SUBJECT = 'No messages sent in Berichtencentrum';
 export const WARNING_EMAIL_TEXT = `
 Hello,
 
-No messages have been sent through the Berichtencentrum since this morning.
+No messages have been sent or received through the Berichtencentrum since this morning.
 You might want to double check if everything is running properly.
 
 Have a nice day,
@@ -51,7 +51,7 @@ Redpencil.io
 
 export const WARNING_EMAIL_HTML = `
 <p>Hello,</p>
-<p>No messages have been sent through the Berichtencentrum since this morning.</p>
+<p>No messages have been sent or received through the Berichtencentrum since this morning.</p>
 <p>You might want to double check if everything is running properly.</p>
 <p>Have a nice day,</p>
 <p>Redpencil.io</p>

--- a/constants.js
+++ b/constants.js
@@ -20,6 +20,8 @@ export const SERVICE_NAME = 'http://lblod.data.gift/services/berichtencentrum-wa
 export const JOB_OPERATION = 'http://lblod.data.gift/id/jobs/concept/JobOperation/berichtencentrumWarning';
 export const CHECK_MESSAGES_OPERATION = 'http://lblod.data.gift/id/jobs/concept/JobOperation/checkMessages';
 
+export const ABB_URI = 'http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b';
+
 export const PREFIXES = `
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
   PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
@@ -42,7 +44,7 @@ export const WARNING_EMAIL_SUBJECT = 'No messages sent in Berichtencentrum';
 export const WARNING_EMAIL_TEXT = `
 Hello,
 
-No messages have been sent or received through the Berichtencentrum since this morning.
+No activity was detected in the Berichtencentrum since this morning.
 You might want to double check if everything is running properly.
 
 Have a nice day,
@@ -51,7 +53,7 @@ Redpencil.io
 
 export const WARNING_EMAIL_HTML = `
 <p>Hello,</p>
-<p>No messages have been sent or received through the Berichtencentrum since this morning.</p>
+<p>No activity was detected in the Berichtencentrum since this morning.</p>
 <p>You might want to double check if everything is running properly.</p>
 <p>Have a nice day,</p>
 <p>Redpencil.io</p>

--- a/queries.js
+++ b/queries.js
@@ -14,11 +14,11 @@ import {
   TASK_TYPE,
   STATUS_SCHEDULED,
   JOB_OPERATION,
-  CHECK_SENT_MESSAGES_OPERATION,
   OUTBOX,
   WARNING_EMAIL_SUBJECT,
   WARNING_EMAIL_TEXT,
-  WARNING_EMAIL_HTML
+  WARNING_EMAIL_HTML,
+  CHECK_MESSAGES_OPERATION
 } from './constants';
 import {
   EMAIL_FROM,
@@ -67,7 +67,7 @@ export async function createTask(jobUri) {
           mu:uuid ${sparqlEscapeString(taskUuid)} ;
           dct:created ${sparqlEscapeDateTime(now)} ;
           dct:modified ${sparqlEscapeDateTime(now)} ;
-          task:operation ${sparqlEscapeUri(CHECK_SENT_MESSAGES_OPERATION)} ;
+          task:operation ${sparqlEscapeUri(CHECK_MESSAGES_OPERATION)} ;
           task:index ${sparqlEscapeString("0")} ;
           dct:isPartOf ${sparqlEscapeUri(jobUri)} ;
           adms:status ${sparqlEscapeUri(STATUS_SCHEDULED)} .
@@ -104,16 +104,40 @@ export async function updateStatus(uri, status) {
 }
 
 /**
- * Gets the number of berichtencentrum messages sent since the given time
+ * Gets the number of messages sent by ABB since the given time.
+ * That monitors that the sync with Kalliope and Loket are running.
  */
-export async function getNumberOfSentMessagesSince(time) {
+export async function getIncomingMessagesNumberSince(time) {
   const q = `
     ${PREFIXES}
     SELECT DISTINCT ?message
     WHERE {
       GRAPH ?g {
         ?message a schema:Message ;
-          schema:dateSent ?sentDate .
+          schema:dateSent ?sentDate ;
+          schema:sender <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> .
+      }
+      FILTER (STR(?sentDate) >= STR(${sparqlEscapeDateTime(time)}))
+    }
+  `;
+
+  const result = await query(q);
+  return result.results.bindings.length;
+}
+
+/**
+ * Gets the number of messages sent by bestuurseenheiden to ABB since the given time.
+ * That monitors that Loket is running.
+ */
+export async function getOutgoingMessagesNumberSince(time) {
+  const q = `
+    ${PREFIXES}
+    SELECT DISTINCT ?message
+    WHERE {
+      GRAPH ?g {
+        ?message a schema:Message ;
+          schema:dateSent ?sentDate ;
+          schema:recipient <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> .
       }
       FILTER (STR(?sentDate) >= STR(${sparqlEscapeDateTime(time)}))
     }

--- a/queries.js
+++ b/queries.js
@@ -18,7 +18,8 @@ import {
   WARNING_EMAIL_SUBJECT,
   WARNING_EMAIL_TEXT,
   WARNING_EMAIL_HTML,
-  CHECK_MESSAGES_OPERATION
+  CHECK_MESSAGES_OPERATION,
+  ABB_URI
 } from './constants';
 import {
   EMAIL_FROM,
@@ -104,40 +105,18 @@ export async function updateStatus(uri, status) {
 }
 
 /**
- * Gets the number of messages sent by ABB since the given time.
- * That monitors that the sync with Kalliope and Loket are running.
+ * Gets the number of messages sent since the given time.
  */
-export async function getIncomingMessagesNumberSince(time) {
+export async function getNumberOfMessagesSince(time, {sender = undefined, recipient = undefined}) {
   const q = `
     ${PREFIXES}
     SELECT DISTINCT ?message
     WHERE {
       GRAPH ?g {
         ?message a schema:Message ;
-          schema:dateSent ?sentDate ;
-          schema:sender <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> .
-      }
-      FILTER (STR(?sentDate) >= STR(${sparqlEscapeDateTime(time)}))
-    }
-  `;
-
-  const result = await query(q);
-  return result.results.bindings.length;
-}
-
-/**
- * Gets the number of messages sent by bestuurseenheiden to ABB since the given time.
- * That monitors that Loket is running.
- */
-export async function getOutgoingMessagesNumberSince(time) {
-  const q = `
-    ${PREFIXES}
-    SELECT DISTINCT ?message
-    WHERE {
-      GRAPH ?g {
-        ?message a schema:Message ;
-          schema:dateSent ?sentDate ;
-          schema:recipient <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> .
+          ${sender ? `schema:sender ${sparqlEscapeUri(sender)} ;` : ''}
+          ${recipient ? `schema:recipient ${sparqlEscapeUri(recipient)} ;` : ''}
+          schema:dateSent ?sentDate .
       }
       FILTER (STR(?sentDate) >= STR(${sparqlEscapeDateTime(time)}))
     }


### PR DESCRIPTION
The current version of the service checks if incoming AND outgoing messages have passed through the berichtencentrum.
The issue is that it is not giving us any information about the sync with Kalliope running properly.
The change here check if outgoing OR incoming messages have passed through the berichtencentrum, if one if them is at 0 messages we send a warning email.